### PR TITLE
Do not remove the uploaded and installed package

### DIFF
--- a/sly/node/VaultSyncManager.js
+++ b/sly/node/VaultSyncManager.js
@@ -753,11 +753,7 @@
                                             function (zipFileName) {
                                                 return PackMgr.uploadPackage(server, acceptSelfSigned, user, password, zipFileName).then(
                                                     function () {
-                                                        return PackMgr.installPackage(server, acceptSelfSigned, user, password, fullPackageName).then(
-                                                            function () {
-                                                                return PackMgr.deletePackage(server, acceptSelfSigned, user, password, fullPackageName);
-                                                            }
-                                                        );
+                                                        return PackMgr.installPackage(server, acceptSelfSigned, user, password, fullPackageName);
                                                     }
                                                 );
                                             }


### PR DESCRIPTION
When "exporting content package to AEM server" the package that is uploaded and installed is currently removed after installation is complete. This means that you are unable to make use of the restoring older versions via crx/packmgr. This is a useful feature for when you have exported by mistake and essentially removed your existing changes on AEM due to the the export completely replacing the contents on the server. This change would allow you to restore via package manager to bring back you just lost changes.

![image](https://cloud.githubusercontent.com/assets/11269301/13378948/152547ae-de0f-11e5-887b-9e08b7014eba.png)


